### PR TITLE
Ensure files/ are part of the setup.cfg files to copy

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -27,6 +27,7 @@ data_files =
     usr/local/share/ansible/roles/tripleo-upgrade/templates = templates/*
     usr/local/share/ansible/roles/tripleo-upgrade/tests = tests/*
     usr/local/share/ansible/roles/tripleo-upgrade/vars = vars/*
+    usr/local/share/ansible/roles/tripleo-upgrade/files = files/*
     playbooks = playbooks/*
 
 [wheel]


### PR DESCRIPTION
When installing tripleo-upgrade into a .quickstart environment, the files/ folder wasn't getting copied, which is necessary at least for "adjust ssh config to skip host key check" in create-upgrade-scripts.yaml.